### PR TITLE
Correction in print_number and print_string

### DIFF
--- a/factorisation/app.asm
+++ b/factorisation/app.asm
@@ -1,96 +1,116 @@
 section .data
-    n dq 60               ; Número a factorizar (ejemplo: 60)
-    factor dq 2           ; Primer factor a probar
-    result db "Factores primos: ", 0
+    n dq 60               ; Number to factorize (example: 60)
+    factor dq 2           ; First factor to test
+    result db "Prime factors: ", 0
 
 section .bss
-    temp resq 1           ; Espacio para almacenar temporalmente n
+    temp resq 1           ; Space to temporarily store n
 
 section .text
     global _start
 
 _start:
-    ; Copiar n a temp
+    ; Copy n to temp
     mov rax, [n]
     mov [temp], rax
 
-    ; Imprimir el mensaje inicial
+    ; Print the initial message
     mov rsi, result
     call print_string
 
-    ; Dividir por 2 hasta que ya no sea divisible
+    ; Divide by 2 until it is no longer divisible
+    mov rdi, 2
 div_loop:
     mov rax, [temp]
-    mov rbx, [factor]
-    xor rdx, rdx          ; Limpiar rdx antes de la división
-    div rbx               ; rax = rax / rbx; rdx = rax % rbx
+    xor rdx, rdx          ; Clear rdx before division
+    div rdi               ; rax = rax / rdi; rdx = rax % rdi
 
-    test rdx, rdx         ; ¿Es divisible?
-    jnz next_factor       ; Si no, probar con el siguiente factor
+    test rdx, rdx         ; Is it divisible?
+    jnz next_factor       ; If not, test the next factor
 
-    ; Si es divisible, imprimir el factor
+    ; If divisible, print the factor
+    mov rsi, rdi
     call print_number
 
-    ; Actualizar temp y repetir la división
+    ; Update temp and repeat division
     mov [temp], rax
     jmp div_loop
 
 next_factor:
-    ; Incrementar el factor en 1
-    add qword [factor], 1
+    ; Increment the factor by 1
+    add rdi, 1
 
-    ; Chequear si el cuadrado del factor es mayor que n
-    mov rax, [factor]
+    ; Check if the square of the factor is greater than n
+    mov rax, [temp]
     imul rax, rax
-    cmp rax, [temp]
+    cmp rax, [n]
     jle div_loop
 
-    ; Imprimir el número restante si es mayor que 2
+    ; Print the remaining number if greater than 2
     mov rax, [temp]
     cmp rax, 2
     jle done
 
-    ; Imprimir el número restante
+    ; Print the remaining number
+    mov rsi, rax
     call print_number
 
 done:
-    ; Salir del programa
+    ; Exit the program
     mov rax, 60           ; syscall: exit
-    xor rdi, rdi          ; código de salida 0
+    xor rdi, rdi          ; exit code 0
     syscall
 
-; Subrutina para imprimir un número (en decimal)
+; Subroutine to print a number (in decimal)
 print_number:
+    ; Convert number to ASCII decimal
     mov rbx, 10           ; Base 10
-print_loop:
-    xor rdx, rdx
-    div rbx               ; Divide rax entre 10, cociente en rax, resto en rdx
-    add dl, '0'           ; Convertir el dígito a ASCII
-    push rdx              ; Almacenar en la pila
-    test rax, rax         ; ¿Es el cociente 0?
-    jnz print_loop        ; Si no, continuar dividiendo
+    mov rcx, rsi          ; Number to print
+    mov rdx, 0            ; Reset digit index
 
-print_digit:
+    ; Find the number of digits
+find_digits:
+    xor rax, rax
+    div rbx               ; Divide rcx by 10, quotient in rax, remainder in rdx
+    push rdx              ; Store the digit on the stack
+    test rcx, rcx         ; Are there more digits?
+    jnz find_digits       ; If yes, continue
+
+    ; Print the digits
+print_digits:
     pop rax
-    call print_char
-    test rsp, rsp
-    jnz print_digit
-
-    mov rax, 32           ; Imprimir un espacio
-    call print_char
-    ret
-
-; Subrutina para imprimir una cadena de caracteres
-print_string:
-    mov rdx, rsi          ; Puntero a la cadena
-    call print_char
-    ret
-
-; Subrutina para imprimir un carácter
-print_char:
-    mov rdi, 1            ; file descriptor 1 es stdout
-    mov rsi, rdx          ; Dirección del carácter a imprimir
-    mov rdx, 1            ; Longitud 1
+    add al, '0'           ; Convert digit to ASCII
+    mov rdi, 1            ; file descriptor 1 is stdout
+    mov rsi, rax          ; Address of the character to print
+    mov rdx, 1            ; Length 1
     mov rax, 1            ; syscall: write
+    syscall
+    test rsp, rsp
+    jnz print_digits
+
+    ; Print a space
+    mov al, ' '
+    mov rdi, 1
+    mov rsi, rax
+    mov rdx, 1
+    mov rax, 1
+    syscall
+
+    ret
+
+; Subroutine to print a string of characters
+print_string:
+    ; Print the string until the end
+    mov rdi, 1            ; file descriptor 1 is stdout
+    mov rax, 1            ; syscall: write
+    mov rdx, 0            ; Length of the string
+find_length:
+    mov al, [rsi + rdx]  ; Read the next character
+    test al, al           ; Is it the end of the string?
+    jz print_string_end  ; If yes, finish
+    inc rdx               ; Increase length
+    jmp find_length
+
+print_string_end:
     syscall
     ret


### PR DESCRIPTION
The `print_number` and `print_string` subroutines need adjustments. The `print_string` subroutine is not properly defined, and the `print_number` subroutine is printing numbers but not in the most efficient way.

```asm
; Subroutine to print a number (in decimal)
print_number:
    ; Convert number to ASCII decimal
    mov rbx, 10           ; Base 10
    mov rcx, rsi          ; Number to print
    mov rdx, 0            ; Reset digit index

    ; Find the number of digits
find_digits:
    xor rax, rax
    div rbx               ; Divide rcx by 10, quotient in rax, remainder in rdx
    push rdx              ; Store the digit on the stack
    test rcx, rcx         ; Are there more digits?
    jnz find_digits       ; If yes, continue

    ; Print the digits
print_digits:
    pop rax
    add al, '0'           ; Convert digit to ASCII
    mov rdi, 1            ; file descriptor 1 is stdout
    mov rsi, rax          ; Address of the character to print
    mov rdx, 1            ; Length 1
    mov rax, 1            ; syscall: write
    syscall
    test rsp, rsp
    jnz print_digits

    ; Print a space
    mov al, ' '
    mov rdi, 1
    mov rsi, rax
    mov rdx, 1
    mov rax, 1
    syscall

    ret

; Subroutine to print a string of characters
print_string:
    ; Print the string until the end
    mov rdi, 1            ; file descriptor 1 is stdout
    mov rax, 1            ; syscall: write
    mov rdx, 0            ; Length of the string
find_length:
    mov al, [rsi + rdx]  ; Read the next character
    test al, al           ; Is it the end of the string?
    jz print_string_end  ; If yes, finish
    inc rdx               ; Increase length
    jmp find_length

print_string_end:
    syscall
    ret
```